### PR TITLE
AWS Helper module that uploads saved files to S3 path

### DIFF
--- a/awsHelper/aws_helper.go
+++ b/awsHelper/aws_helper.go
@@ -1,0 +1,110 @@
+// Copyright © 2020 Inside-Track
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsHelper
+
+import (
+	"log"
+  "net/http"
+	"bytes"
+  "os"
+  "errors"
+  "strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+  "github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
+  "github.com/aws/aws-sdk-go/aws/credentials"
+  "github.com/aws/aws-sdk-go/aws/session"
+  "github.com/aws/aws-sdk-go/service/s3"
+)
+
+var (
+  s3Bucket, awsKey, awsSecret string
+)
+
+func NewAWSHelper(awsKeyID string, awsSecretAcessKey string, awsS3Bucket string) {
+  s3Bucket = awsS3Bucket
+  awsKey = awsKeyID
+  awsSecret = awsSecretAcessKey
+}
+
+func UploadToS3(path string) (string, error) {
+    if (len(strings.TrimSpace(awsKey)) == 0 || len(strings.TrimSpace(awsSecret)) == 0 || len(strings.TrimSpace(s3Bucket)) == 0 ) {
+      return "", errors.New("Invalid AWS Credentials, Skipping S3 Uploads..") 
+    }
+
+    // All clients require a Session. The Session provides the client with
+   	// shared configuration such as region, endpoint, and credentials. A
+   	// Session should be shared where possible to take advantage of
+   	// configuration and credential caching. See the session package for
+   	// more information.
+  	sess := session.Must(session.NewSession(
+      &aws.Config{
+        Region: aws.String("us-west-2"),
+        Credentials: credentials.NewStaticCredentials(
+          awsKey,
+          awsSecret,
+          "", // a token will be created when the session it's used.
+        ),
+      }),
+    )
+
+  	// Open the file for use
+    file, err := os.Open(path)
+    if err != nil {
+        return "", err
+    }
+    defer file.Close()
+
+    // Get file size and read the file content into a buffer
+    fileInfo, _ := file.Stat()
+    var size int64 = fileInfo.Size()
+    buffer := make([]byte, size)
+    file.Read(buffer)
+
+    // Create a new instance of the service's client with a Session.
+    // Optional aws.Config values can also be provided as variadic arguments
+    // to the New function. This option allows you to provide service
+    // specific configuration.
+    svc := s3.New(sess)
+
+	  // Uploads the object to S3. Config settings: this is where you choose the bucket,
+    // filename, content-type and storage class of the file you're uploading
+  	_, err = svc.PutObject(&s3.PutObjectInput{
+  		Bucket: aws.String(s3Bucket),
+      Key:  aws.String(path),
+      Body: bytes.NewReader(buffer),
+      ACL:  aws.String("private"),
+      ContentType:  aws.String(http.DetectContentType(buffer)),
+      ContentLength:  aws.Int64(int64(size)),
+      ContentDisposition: aws.String("attachment"),
+      ServerSideEncryption: aws.String("AES256"),
+      StorageClass: aws.String("INTELLIGENT_TIERING"),
+  	})
+
+  	if err != nil {
+  		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == request.CanceledErrorCode {
+  			// If the SDK can determine the request or retry delay was canceled
+  			// by a context the CanceledErrorCode error code will be returned.
+        log.Fatalf("Upload canceled due to timeout, %s\n", err)
+  		} else {
+  			log.Fatalf("Failed to upload object, %s\n", err)
+  		}
+  		return "", err
+  	}
+
+  	log.Printf("successfully uploaded file to %s/%s\n", s3Bucket, path)
+  	return path, nil
+}

--- a/cmd/out.go
+++ b/cmd/out.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/inside-track/rabbitio/file"
 	"github.com/inside-track/rabbitio/rmq"
+	"github.com/inside-track/rabbitio/awsHelper"
 	"github.com/spf13/cobra"
 )
 
@@ -46,6 +47,8 @@ var outCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		awsHelper.NewAWSHelper(awsKey, awsSecret, s3Bucket)
 
 		go rabbit.Consume(channel, verify)
 


### PR DESCRIPTION
**Description:**

Creating an AWS module that gets its configuration through CMD parameters (AWS KEY, SECRET and S3Bucket), that uploads the file (once saved) into S3 into a custom bucket path (e.g: https://s3.console.aws.amazon.com/s3/buckets/rabbitmq-backups-rabbitio/?region=us-west-2&tab=overview)

**Testing:**
- Ran `go build -a` --> gets a binary out `rabbitio`
- Ran `./rabbitio out -e staging -q test-rabbitio -u amqp://<username>:<password>@rabbitmq-staging.ucoachapp.com:5672 --awsKey <aws_key> --awsSecret <aws_secret> --s3Bucket rabbitmq-backups-rabbitio`

- 
![Screen Shot 2020-09-24 at 5 04 20 PM](https://user-images.githubusercontent.com/1479894/94165360-6912c080-fe8a-11ea-9b33-2c1f625d22b0.png)

- Messages uploaded successfully to S3:
![Screen Shot 2020-09-24 at 5 21 58 PM](https://user-images.githubusercontent.com/1479894/94165429-7e87ea80-fe8a-11ea-8534-6953471ee051.png)


**Next?**
- It uploads only the first ~2k messages leaving the others and disconnecting, will look into fixing it.
