### PR TITLE
Fix acknowledging consumed messages

### DIFF
--- a/rmq/consume.go
+++ b/rmq/consume.go
@@ -81,7 +81,7 @@ func (r *RabbitMQ) Consume(out chan Message, verify <-chan Verify) {
 	deliveries, err := r.channel.Consume(
 		r.queue, // name
 		r.tag,   // consumerTag,
-		true,   // autoAck
+		false,   // noAck
 		false,   // exclusive
 		false,   // noLocal
 		false,   // noWait
@@ -101,11 +101,6 @@ func (r *RabbitMQ) Consume(out chan Message, verify <-chan Verify) {
 			DeliveryTag: d.DeliveryTag,
 		}
 
-		if err := d.Ack(false); err != nil {
-			log.Printf("Error acknowledging message : %s", err)
-		} else {
-			log.Printf("Acknowledged message.")
-		}
 		// write Message to channel
 		out <- msg
 	}


### PR DESCRIPTION
Previously it was consuming only 1k messages and then waits forever, fixing this behavior, now it consumed all messages in the test queue (>50k) and ack'd them successfully, files were all saved into files and uploaded to S3.